### PR TITLE
Use quarkus-container-image-docker to build image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@ under the License.
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-container-image-jib</artifactId>
+            <artifactId>quarkus-container-image-docker</artifactId>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
Kameleon uses maven in runtime to generate projects.
That is why we are generating docker image based on custom Dockerfile 