### PR TITLE
refactor: refactor bad smell InnerClassMayBeStatic

### DIFF
--- a/src/main/java/org/apache/camel/kameleon/WarmUpService.java
+++ b/src/main/java/org/apache/camel/kameleon/WarmUpService.java
@@ -81,7 +81,7 @@ public class WarmUpService {
         }
     }
 
-    public class WarmupRequest {
+    public static class WarmupRequest {
         public String type;
         public String version;
         public String javaVersion;


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## InnerClassMayBeStatic
Inner classes that do not reference their enclosing instances can be made static.
This prevents a common cause of memory leaks and uses less memory per instance of the class.

<!-- fingerprint:1949634091 -->
# Repairing Code Style Issues
* InnerClassMayBeStatic (1)
